### PR TITLE
Updates test infrastructure to work with supported Python versions.

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,5 +1,7 @@
+import pytest
+
 import spectra
-import nose
+
 
 def test_polylinear():
     """
@@ -13,8 +15,9 @@ def test_polylinear():
     goal = ['#ffff00', '#ff8000', '#ff0000', '#800000', '#000000']
     assert(results == goal)
 
-@nose.tools.raises(ValueError)
+
 def test_polylinear_fail():
     colors = ['yellow', 'red', 'black']
     domain = [ 0, 50 ] # Domain has one too few items
-    spectra.scale(colors).domain(domain)
+    with pytest.raises(ValueError):
+        spectra.scale(colors).domain(domain)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+min_version = 4.0
+envlist = py38,py39,py310,py311,py312,py313
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
-deps=nose
-commands=nosetests
+deps = pytest
+commands = pytest {posargs}


### PR DESCRIPTION
The nose test-runner is in maintenance mode, and does not support recent Python versions.

The tests are updated to use pytest, and the versions tested by tox are from Python 3.8 to Python 3.13, which are the most recent versions supported by tox.